### PR TITLE
remove kbv patient details for unknown patient

### DIFF
--- a/Resources/fsh-generated/resources/Bundle-ff0406a7-b0c2-4426-82fd-8e49e72814da.json
+++ b/Resources/fsh-generated/resources/Bundle-ff0406a7-b0c2-4426-82fd-8e49e72814da.json
@@ -58,20 +58,18 @@
         },
         "name": [
           {
-            "use": "official",
             "family": "TK-eAU-Schmidt",
             "given": [
               "Wolfgang"
             ]
           }
         ],
+        "birthDate": "1991-01-04",
         "address": [
           {
-            "type": "both",
             "postalCode": "40221"
           }
-        ],
-        "birthDate": "1991-01-04"
+        ]
       }
     },
     {

--- a/Resources/fsh-generated/resources/Patient-1df9e029-2505-4551-b735-f1c1a1e2d889.json
+++ b/Resources/fsh-generated/resources/Patient-1df9e029-2505-4551-b735-f1c1a1e2d889.json
@@ -8,18 +8,16 @@
   },
   "name": [
     {
-      "use": "official",
       "family": "TK-eAU-Schmidt",
       "given": [
         "Wolfgang"
       ]
     }
   ],
+  "birthDate": "1991-01-04",
   "address": [
     {
-      "type": "both",
       "postalCode": "40221"
     }
-  ],
-  "birthDate": "1991-01-04"
+  ]
 }

--- a/Resources/fsh-generated/resources/StructureDefinition-eeb-unknown-patient.json
+++ b/Resources/fsh-generated/resources/StructureDefinition-eeb-unknown-patient.json
@@ -66,39 +66,15 @@
         "fixedCanonical": "https://gematik.de/fhir/eeb/StructureDefinition/EEBUnknownPatient"
       },
       {
-        "id": "Patient.name",
-        "path": "Patient.name",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "use"
-            }
-          ],
-          "rules": "closed"
-        },
+        "id": "Patient.name.family",
+        "path": "Patient.name.family",
+        "min": 1
+      },
+      {
+        "id": "Patient.name.given",
+        "path": "Patient.name.given",
         "min": 1,
         "max": "1"
-      },
-      {
-        "id": "Patient.name:name",
-        "path": "Patient.name",
-        "sliceName": "name",
-        "min": 1,
-        "max": "1",
-        "type": [
-          {
-            "code": "HumanName",
-            "profile": [
-              "https://fhir.kbv.de/StructureDefinition/KBV_PR_Base_Datatype_Name"
-            ]
-          }
-        ]
-      },
-      {
-        "id": "Patient.name:name.given",
-        "path": "Patient.name.given",
-        "min": 1
       },
       {
         "id": "Patient.birthDate",
@@ -106,37 +82,7 @@
         "min": 1
       },
       {
-        "id": "Patient.address",
-        "path": "Patient.address",
-        "slicing": {
-          "discriminator": [
-            {
-              "type": "value",
-              "path": "type"
-            }
-          ],
-          "rules": "closed"
-        },
-        "min": 1,
-        "max": "1"
-      },
-      {
-        "id": "Patient.address:Strassenanschrift",
-        "path": "Patient.address",
-        "sliceName": "Strassenanschrift",
-        "min": 1,
-        "max": "1",
-        "type": [
-          {
-            "code": "Address",
-            "profile": [
-              "https://fhir.kbv.de/StructureDefinition/KBV_PR_Base_Datatype_Street_Address"
-            ]
-          }
-        ]
-      },
-      {
-        "id": "Patient.address:Strassenanschrift.postalCode",
+        "id": "Patient.address.postalCode",
         "path": "Patient.address.postalCode",
         "min": 1
       }

--- a/Resources/input/fsh/profiles/EEBUnknownPatient.fsh
+++ b/Resources/input/fsh/profiles/EEBUnknownPatient.fsh
@@ -6,24 +6,10 @@ Id: eeb-unknown-patient
 * meta 1..1
 * meta.profile 1..1
 * meta.profile = "https://gematik.de/fhir/eeb/StructureDefinition/EEBUnknownPatient" (exactly)
-* name 1..1
-* name ^slicing.discriminator.type = #value
-* name ^slicing.discriminator.path = "use"
-* name ^slicing.rules = #closed
-* name contains
-    name 1..1
-* name[name] only $kbv_pr_base_datatype_name
-* name[name].family 1..1
-* name[name].given 1..1
+* name.family 1..1
+* name.given 1..1
 * birthDate 1..1
-* address 1..1
-* address ^slicing.discriminator.type = #value
-* address ^slicing.discriminator.path = "type"
-* address ^slicing.rules = #closed
-* address contains
-    Strassenanschrift 1..1
-* address[Strassenanschrift] only $kbv_pr_base_datatype_street_address
-* address[Strassenanschrift].postalCode 1..1
+* address.postalCode 1..1
 
 
 // Beispielgenerierung
@@ -33,7 +19,7 @@ Title: "EEBUnknownPatient"
 Usage: #example
 * id = "1df9e029-2505-4551-b735-f1c1a1e2d889"
 * meta.profile = "https://gematik.de/fhir/eeb/StructureDefinition/EEBUnknownPatient"
-* name[name].family = "TK-eAU-Schmidt"
-* name[name].given = "Wolfgang"
+* name.family = "TK-eAU-Schmidt"
+* name.given = "Wolfgang"
 * birthDate = "1991-01-04"
-* address[Strassenanschrift].postalCode = "40221"
+* address.postalCode = "40221"


### PR DESCRIPTION
Den UnknownPatient analog zum KBV_PR_FOR_Patient zu bauen ist eher hinderlich als förderlich, da dadurch unnötige Pflichtfelder gesetzt werden müssen. Besser keep it simple.